### PR TITLE
Add sell modal workflow to investments page

### DIFF
--- a/css/components/hero.css
+++ b/css/components/hero.css
@@ -55,6 +55,13 @@
     -webkit-text-fill-color: transparent;
     white-space: normal;
     line-height: 1.15;
+    background-size: 100% auto;
+    animation: none;
+}
+
+body.animations-enabled .hero h1 {
+    animation: none !important;
+    background-size: 100% auto !important;
 }
 
 /* Remove these styles since we're combining the text */

--- a/css/sections/investments.css
+++ b/css/sections/investments.css
@@ -227,7 +227,8 @@
 }
 
 .sell-cta__content h2 {
-    margin-bottom: 16px;
+    margin: 0 0 16px;
+    white-space: normal;
 }
 
 .sell-cta__summary {

--- a/css/sections/investments.css
+++ b/css/sections/investments.css
@@ -200,6 +200,359 @@
     z-index: 1;
 }
 
+.portfolio-actions {
+    padding: 120px 0;
+    background: radial-gradient(circle at 15% 20%, rgba(29, 185, 84, 0.12), transparent 55%),
+                radial-gradient(circle at 85% 30%, rgba(29, 185, 84, 0.08), transparent 60%),
+                linear-gradient(180deg, rgba(10, 10, 10, 0.95) 0%, rgba(5, 5, 5, 0.98) 100%);
+}
+
+.sell-cta {
+    display: grid;
+    gap: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    align-items: center;
+    padding: 48px;
+    border-radius: 28px;
+    background: linear-gradient(140deg, rgba(16, 16, 16, 0.95) 0%, rgba(25, 25, 25, 0.92) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 32px 55px rgba(0, 0, 0, 0.45);
+}
+
+.sell-cta__content h2 {
+    margin-bottom: 16px;
+}
+
+.sell-cta__summary {
+    display: grid;
+    gap: 18px;
+    padding: 24px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(29, 185, 84, 0.18);
+}
+
+.sell-cta__metric {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.sell-cta__label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+}
+
+.sell-cta__button {
+    justify-self: start;
+    padding: 18px 34px;
+    border-radius: 999px;
+    border: none;
+    cursor: pointer;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    background: linear-gradient(135deg, var(--secondary) 0%, #4beb8a 100%);
+    color: #0b0b0b;
+    box-shadow: 0 24px 45px rgba(29, 185, 84, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.sell-cta__button:hover,
+.sell-cta__button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 30px 55px rgba(29, 185, 84, 0.45);
+}
+
+.sell-modal[hidden] {
+    display: none;
+}
+
+.sell-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    display: grid;
+    place-items: center;
+}
+
+.sell-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(8, 8, 8, 0.82);
+    backdrop-filter: blur(10px);
+}
+
+.sell-modal__dialog {
+    position: relative;
+    width: min(640px, calc(100% - 32px));
+    max-height: calc(100vh - 80px);
+    padding: 42px;
+    border-radius: 28px;
+    background: linear-gradient(170deg, rgba(20, 20, 20, 0.98) 0%, rgba(8, 8, 8, 0.96) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 45px 80px rgba(0, 0, 0, 0.55);
+    overflow-y: auto;
+}
+
+.sell-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text);
+    cursor: pointer;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.sell-modal__close svg {
+    width: 20px;
+    height: 20px;
+}
+
+.sell-modal__close:hover,
+.sell-modal__close:focus-visible {
+    transform: rotate(4deg) scale(1.05);
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.sell-modal__header {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 28px;
+}
+
+.sell-modal__eyebrow {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--secondary);
+}
+
+.sell-modal__intro {
+    color: var(--text-secondary);
+}
+
+.sell-form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.sell-form__field label,
+.sell-form__toggle-label,
+.sell-input label,
+.sell-auto__cap label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+}
+
+.sell-form select,
+.sell-input input,
+.sell-auto__cap input {
+    width: 100%;
+    border-radius: 16px;
+    padding: 14px 16px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(29, 185, 84, 0.18);
+    color: var(--text);
+}
+
+.sell-form select:focus,
+.sell-input input:focus,
+.sell-auto__cap input:focus {
+    outline: none;
+    border-color: var(--secondary);
+    box-shadow: 0 0 0 3px rgba(29, 185, 84, 0.25);
+}
+
+.sell-form__toggle {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    padding: 16px;
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.sell-form__toggle legend {
+    font-weight: 600;
+    margin-right: auto;
+}
+
+.sell-form__toggle-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.sell-form__toggle-option input {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--secondary);
+}
+
+.sell-form__toggle-option:hover,
+.sell-form__toggle-option:focus-within,
+.sell-form__toggle-option.is-selected {
+    background: rgba(29, 185, 84, 0.2);
+}
+
+.sell-form__fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 20px;
+}
+
+.sell-input input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.sell-slider {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.sell-slider__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.sell-slider__range {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.sell-slider input[type="range"] {
+    accent-color: var(--secondary);
+}
+
+.sell-slider__value {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.sell-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+}
+
+.sell-summary__item {
+    padding: 18px;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(29, 185, 84, 0.16);
+}
+
+.sell-summary__label {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    margin-bottom: 6px;
+}
+
+.sell-summary__value {
+    font-weight: 700;
+    font-size: 1.1rem;
+}
+
+.sell-auto {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 18px;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.sell-auto__checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-weight: 600;
+}
+
+.sell-auto__checkbox input {
+    width: 22px;
+    height: 22px;
+    accent-color: var(--secondary);
+}
+
+.sell-auto__cap {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 200px;
+}
+
+.sell-auto__cap input:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.sell-form__submit {
+    align-self: stretch;
+    padding: 16px;
+    border-radius: 16px;
+    border: none;
+    background: linear-gradient(135deg, var(--secondary) 0%, #4beb8a 100%);
+    color: #0b0b0b;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    box-shadow: 0 20px 40px rgba(29, 185, 84, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.sell-form__submit:hover,
+.sell-form__submit:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 26px 50px rgba(29, 185, 84, 0.45);
+}
+
+body.sell-modal-open {
+    overflow: hidden;
+}
+
+@media (max-width: 768px) {
+    .sell-cta {
+        padding: 32px;
+    }
+
+    .sell-modal__dialog {
+        padding: 32px 24px;
+        max-height: calc(100vh - 40px);
+    }
+}
+
 .cash-card,
 .holdings-card {
     grid-column: 1 / -1;

--- a/css/sections/investments.css
+++ b/css/sections/investments.css
@@ -210,13 +210,20 @@
 .sell-cta {
     display: grid;
     gap: 32px;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    align-items: center;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    grid-template-areas:
+        "content summary"
+        "button summary";
+    align-items: start;
     padding: 48px;
     border-radius: 28px;
     background: linear-gradient(140deg, rgba(16, 16, 16, 0.95) 0%, rgba(25, 25, 25, 0.92) 100%);
     border: 1px solid rgba(255, 255, 255, 0.08);
     box-shadow: 0 32px 55px rgba(0, 0, 0, 0.45);
+}
+
+.sell-cta__content {
+    grid-area: content;
 }
 
 .sell-cta__content h2 {
@@ -230,6 +237,8 @@
     border-radius: 20px;
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(29, 185, 84, 0.18);
+    grid-area: summary;
+    align-self: stretch;
 }
 
 .sell-cta__metric {
@@ -246,7 +255,9 @@
 }
 
 .sell-cta__button {
+    grid-area: button;
     justify-self: start;
+    align-self: end;
     padding: 18px 34px;
     border-radius: 999px;
     border: none;
@@ -545,6 +556,11 @@ body.sell-modal-open {
 @media (max-width: 768px) {
     .sell-cta {
         padding: 32px;
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "content"
+            "summary"
+            "button";
     }
 
     .sell-modal__dialog {

--- a/css/sections/property-details.css
+++ b/css/sections/property-details.css
@@ -198,6 +198,354 @@
     -webkit-text-fill-color: transparent;
 }
 
+.buy-cta {
+    margin-top: 48px;
+    display: flex;
+    justify-content: center;
+}
+
+.buy-button {
+    padding: 16px 32px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--secondary) 0%, #4beb8a 100%);
+    color: #0b0b0b;
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    border: none;
+    cursor: pointer;
+    box-shadow: 0 18px 35px rgba(29, 185, 84, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.buy-button:hover,
+.buy-button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 45px rgba(29, 185, 84, 0.45);
+}
+
+.buy-modal[hidden] {
+    display: none;
+}
+
+.buy-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+}
+
+.buy-modal__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+}
+
+.buy-modal__dialog {
+    position: relative;
+    width: min(520px, 100%);
+    background: linear-gradient(160deg, rgba(26, 26, 26, 0.98) 0%, rgba(14, 14, 14, 0.98) 100%);
+    border-radius: 24px;
+    border: 1px solid rgba(29, 185, 84, 0.16);
+    padding: 36px;
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    color: var(--text);
+}
+
+.buy-modal__close {
+    position: absolute;
+    top: 18px;
+    right: 18px;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 999px;
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.buy-modal__close:hover,
+.buy-modal__close:focus-visible {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text);
+}
+
+.buy-modal__intro {
+    margin: 0;
+    color: var(--text-secondary);
+}
+
+.buy-form {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.buy-form__toggle {
+    display: inline-flex;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(29, 185, 84, 0.16);
+    border-radius: 999px;
+    padding: 6px;
+    gap: 6px;
+    width: fit-content;
+}
+
+.toggle-option {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 20px;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: background 0.3s ease, color 0.3s ease;
+}
+
+.toggle-option input {
+    position: absolute;
+    opacity: 0;
+}
+
+.toggle-option input:checked + span,
+.toggle-option:hover span {
+    color: #0b0b0b;
+}
+
+.toggle-option input:checked + span {
+    background: linear-gradient(135deg, var(--secondary) 0%, #4beb8a 100%);
+    border-radius: inherit;
+    padding: 10px 20px;
+    box-shadow: 0 10px 25px rgba(29, 185, 84, 0.35);
+}
+
+.toggle-option span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 20px;
+    border-radius: inherit;
+    transition: inherit;
+}
+
+.buy-form__fields {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.form-field.is-active label {
+    color: var(--secondary);
+}
+
+.form-field.is-active input:not(:disabled) {
+    border-color: var(--secondary);
+    box-shadow: 0 0 0 2px rgba(29, 185, 84, 0.25);
+}
+
+.form-field label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+}
+
+.form-field input {
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(29, 185, 84, 0.18);
+    padding: 14px 16px;
+    color: var(--text);
+    font-size: 1rem;
+    transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.form-field input:focus-visible {
+    border-color: var(--secondary);
+    box-shadow: 0 0 0 3px rgba(29, 185, 84, 0.25);
+    outline: none;
+}
+
+.form-field input:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.buy-slider {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.buy-slider__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.buy-slider__header label {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.buy-slider__range {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.buy-slider input[type="range"] {
+    accent-color: var(--secondary);
+}
+
+.buy-summary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+}
+
+.summary-item {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 16px;
+    border: 1px solid rgba(29, 185, 84, 0.16);
+    padding: 18px;
+}
+
+.summary-item .label {
+    display: block;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+}
+
+.summary-item strong {
+    font-size: 1.2rem;
+}
+
+.auto-invest {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.auto-invest__checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+}
+
+.auto-invest__checkbox input {
+    width: 20px;
+    height: 20px;
+    accent-color: var(--secondary);
+}
+
+.auto-invest__cap {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 200px;
+}
+
+.auto-invest__cap label {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+}
+
+.auto-invest__cap input {
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(29, 185, 84, 0.18);
+    padding: 12px 14px;
+    color: var(--text);
+}
+
+.buy-form__submit {
+    align-self: stretch;
+    padding: 16px;
+    border-radius: 14px;
+    border: none;
+    background: linear-gradient(135deg, var(--secondary) 0%, #4beb8a 100%);
+    color: #0b0b0b;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    cursor: pointer;
+    box-shadow: 0 18px 35px rgba(29, 185, 84, 0.35);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.buy-form__submit:hover,
+.buy-form__submit:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 22px 45px rgba(29, 185, 84, 0.45);
+}
+
+body.buy-modal-open {
+    overflow: hidden;
+}
+
+@media (max-width: 768px) {
+    .buy-modal__dialog {
+        padding: 28px 22px;
+    }
+
+    .buy-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .buy-form__toggle {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .toggle-option span {
+        width: 100%;
+    }
+}
+
 .overview-card {
     grid-column: 1 / -1;
 }

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                 <span>Revolutionizing Real Estate</span>
                 <span>Through Blockchain Technology</span>
             </h1>
-            <p><style></style>Rebuilding communities and protecting assets in an era of unprecedented challenges</p>
+            <p>Rebuilding communities and protecting assets in an era of unprecedented challenges</p>
 
             <div class="hero-stats">
                 <div class="crisis-stats">

--- a/investments.html
+++ b/investments.html
@@ -292,6 +292,121 @@
         </div>
     </section>
 
+    <section class="portfolio-actions" aria-labelledby="sellTokensHeading">
+        <div class="container">
+            <div class="sell-cta">
+                <div class="sell-cta__content">
+                    <h2 id="sellTokensHeading">Ready to realise your gains?</h2>
+                    <p>
+                        Review each Bandar Sunway holding, choose the amount or number of tokens to part with, and
+                        arrange a sale in a few clicks. Your available balances below reflect the most recent
+                        portfolio snapshot.
+                    </p>
+                </div>
+                <div class="sell-cta__summary" role="presentation">
+                    <div class="sell-cta__metric">
+                        <span class="sell-cta__label">Total units held</span>
+                        <strong>3,490 units</strong>
+                    </div>
+                    <div class="sell-cta__metric">
+                        <span class="sell-cta__label">Portfolio value</span>
+                        <strong>RM3,677,000</strong>
+                    </div>
+                </div>
+                <button type="button" class="sell-cta__button" id="openSellModal">Sell tokens</button>
+            </div>
+        </div>
+    </section>
+
+    <div class="sell-modal" id="sellModal" hidden>
+        <div class="sell-modal__overlay" data-sell-close></div>
+        <div class="sell-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="sellModalTitle"
+            tabindex="-1">
+            <button type="button" class="sell-modal__close" data-sell-close aria-label="Close sell details">
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+                        stroke-linejoin="round" />
+                </svg>
+            </button>
+            <div class="sell-modal__header">
+                <span class="sell-modal__eyebrow">Portfolio exit</span>
+                <h2 id="sellModalTitle">Schedule a token sale</h2>
+                <p class="sell-modal__intro">
+                    Select the property you would like to exit, decide whether to sell by amount or units, and preview
+                    the expected proceeds before confirming the order.
+                </p>
+            </div>
+            <form class="sell-form" id="sellForm" novalidate>
+                <div class="sell-form__field">
+                    <label for="sellProperty">Choose property</label>
+                    <select id="sellProperty" name="sellProperty">
+                        <option value="lacosta">LaCosta @ Sunway South Quay</option>
+                        <option value="geolake">Sunway GeoLake Residences</option>
+                        <option value="greenfield">Greenfield Residence</option>
+                        <option value="ridzuan">Ridzuan Condominium</option>
+                    </select>
+                </div>
+                <fieldset class="sell-form__toggle" aria-label="Choose sale input mode">
+                    <legend class="sell-form__toggle-label">Amount or Units</legend>
+                    <label class="sell-form__toggle-option">
+                        <input type="radio" name="sellMode" value="amount" checked>
+                        <span>Amount (RM)</span>
+                    </label>
+                    <label class="sell-form__toggle-option">
+                        <input type="radio" name="sellMode" value="units">
+                        <span>Units</span>
+                    </label>
+                </fieldset>
+                <div class="sell-form__fields">
+                    <div class="sell-input">
+                        <label for="sellAmount">Amount (RM)</label>
+                        <input type="number" id="sellAmount" name="sellAmount" inputmode="decimal" min="0"
+                            step="1" placeholder="0.00">
+                    </div>
+                    <div class="sell-input">
+                        <label for="sellUnits">Units</label>
+                        <input type="number" id="sellUnits" name="sellUnits" inputmode="decimal" min="0"
+                            step="1" placeholder="0" disabled>
+                    </div>
+                </div>
+                <div class="sell-slider">
+                    <div class="sell-slider__header">
+                        <label for="sellSlider">Adjust sale size</label>
+                        <span class="sell-slider__range" data-sell-slider-range>0% → 100%</span>
+                    </div>
+                    <input type="range" id="sellSlider" name="sellSlider" min="0" max="100" value="0" step="1">
+                    <span class="sell-slider__value" aria-live="polite" data-sell-slider-value>0% of holdings</span>
+                </div>
+                <div class="sell-summary" aria-live="polite">
+                    <div class="sell-summary__item">
+                        <span class="sell-summary__label">Available units</span>
+                        <span class="sell-summary__value" data-available-units>0</span>
+                    </div>
+                    <div class="sell-summary__item">
+                        <span class="sell-summary__label">Unit price</span>
+                        <span class="sell-summary__value" data-unit-price>RM0.00</span>
+                    </div>
+                    <div class="sell-summary__item">
+                        <span class="sell-summary__label">Estimated proceeds</span>
+                        <span class="sell-summary__value" data-estimated-proceeds>RM0.00</span>
+                    </div>
+                </div>
+                <div class="sell-auto">
+                    <label class="sell-auto__checkbox" for="sellAutoInvest">
+                        <input type="checkbox" id="sellAutoInvest" name="sellAutoInvest">
+                        Auto-invest future payouts?
+                    </label>
+                    <div class="sell-auto__cap">
+                        <label for="sellAutoCap">Cap (% of proceeds)</label>
+                        <input type="number" id="sellAutoCap" name="sellAutoCap" min="0" max="100" step="1"
+                            value="25" disabled>
+                    </div>
+                </div>
+                <button type="submit" class="sell-form__submit">Place sell order</button>
+            </form>
+        </div>
+    </div>
+
     <footer>
         <div class="container">
             <div class="footer-content">
@@ -328,5 +443,6 @@
             </div>
         </div>
     </footer>
+    <script src="js/investments.js"></script>
 </body>
 </html>

--- a/js/animations.js
+++ b/js/animations.js
@@ -20,7 +20,6 @@ document.addEventListener('DOMContentLoaded', () => {
     ], 0.1, 0.06);
 
     addAnimationClass([
-        ...document.querySelectorAll('.hero h1 span'),
         document.querySelector('.hero p'),
         ...document.querySelectorAll('.hero .hero-quote p, .hero .hero-quote .quote-author')
     ], 0.35, 0.12, 'text-glow');

--- a/js/investments.js
+++ b/js/investments.js
@@ -1,0 +1,293 @@
+(function () {
+    const modal = document.getElementById('sellModal');
+    const openButton = document.getElementById('openSellModal');
+
+    if (!modal || !openButton) {
+        return;
+    }
+
+    const dialog = modal.querySelector('.sell-modal__dialog');
+    const closeTriggers = modal.querySelectorAll('[data-sell-close]');
+    const propertySelect = document.getElementById('sellProperty');
+    const modeInputs = Array.from(modal.querySelectorAll('input[name="sellMode"]'));
+    const toggleLabels = Array.from(modal.querySelectorAll('.sell-form__toggle-option'));
+    const amountInput = document.getElementById('sellAmount');
+    const unitsInput = document.getElementById('sellUnits');
+    const slider = document.getElementById('sellSlider');
+    const sliderValue = modal.querySelector('[data-sell-slider-value]');
+    const availableUnitsEl = modal.querySelector('[data-available-units]');
+    const unitPriceEl = modal.querySelector('[data-unit-price]');
+    const proceedsEl = modal.querySelector('[data-estimated-proceeds]');
+    const autoInvestCheckbox = document.getElementById('sellAutoInvest');
+    const autoInvestCap = document.getElementById('sellAutoCap');
+    const form = document.getElementById('sellForm');
+
+    const holdings = {
+        lacosta: { name: 'LaCosta @ Sunway South Quay', units: 1250, value: 1250000 },
+        geolake: { name: 'Sunway GeoLake Residences', units: 940, value: 1080000 },
+        greenfield: { name: 'Greenfield Residence', units: 780, value: 735000 },
+        ridzuan: { name: 'Ridzuan Condominium', units: 520, value: 612000 }
+    };
+
+    Object.values(holdings).forEach((holding) => {
+        holding.pricePerUnit = holding.units ? holding.value / holding.units : 0;
+    });
+
+    const currencyFormatter = new Intl.NumberFormat('en-MY', {
+        style: 'currency',
+        currency: 'MYR',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+
+    const unitsFormatter = new Intl.NumberFormat('en-MY', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 2
+    });
+
+    let currentMode = 'amount';
+    let previouslyFocusedElement = null;
+
+    autoInvestCap.disabled = !autoInvestCheckbox.checked;
+
+    function formatCurrency(value) {
+        return currencyFormatter.format(value || 0);
+    }
+
+    function formatUnits(value) {
+        return `${unitsFormatter.format(value || 0)} units`;
+    }
+
+    function getHolding() {
+        return holdings[propertySelect.value];
+    }
+
+    function clampUnits(units, holding) {
+        if (!holding) {
+            return 0;
+        }
+        return Math.min(Math.max(units, 0), holding.units);
+    }
+
+    function toAmountInput(value) {
+        if (!Number.isFinite(value)) {
+            return '';
+        }
+        return (Math.round(value * 100) / 100).toFixed(2);
+    }
+
+    function toUnitsInput(value) {
+        if (!Number.isFinite(value)) {
+            return '';
+        }
+        const rounded = Math.round(value * 100) / 100;
+        if (Math.abs(rounded) < 0.005) {
+            return '0';
+        }
+        return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(2);
+    }
+
+    function syncToggleStyles() {
+        toggleLabels.forEach((label) => {
+            const input = label.querySelector('input');
+            label.classList.toggle('is-selected', input && input.checked);
+        });
+    }
+
+    function updateMode() {
+        amountInput.disabled = currentMode !== 'amount';
+        unitsInput.disabled = currentMode !== 'units';
+        syncToggleStyles();
+        updateFromUnits(parseFloat(unitsInput.value) || 0, { origin: 'mode' });
+    }
+
+    function updateAvailableMeta(holding) {
+        availableUnitsEl.textContent = formatUnits(holding.units);
+        unitPriceEl.textContent = formatCurrency(holding.pricePerUnit);
+    }
+
+    function updateSliderValueDisplay(units, amount) {
+        const holding = getHolding();
+        const percent = holding && holding.units
+            ? Math.round((units / holding.units) * 100)
+            : 0;
+        const detail = currentMode === 'amount' ? formatCurrency(amount) : formatUnits(units);
+        sliderValue.textContent = `${percent}% of holdings (${detail})`;
+    }
+
+    function updateSliderFromUnits(units) {
+        const holding = getHolding();
+        if (!holding || !holding.units) {
+            slider.value = 0;
+            sliderValue.textContent = '0% of holdings';
+            return;
+        }
+        const percent = Math.round((units / holding.units) * 100);
+        slider.value = Math.min(Math.max(percent, 0), 100);
+        updateSliderValueDisplay(units, units * holding.pricePerUnit);
+    }
+
+    function updateFromUnits(units, options = {}) {
+        const holding = getHolding();
+        if (!holding) {
+            return;
+        }
+        const clampedUnits = clampUnits(units, holding);
+        const amount = clampedUnits * holding.pricePerUnit;
+
+        if (options.origin !== 'units') {
+            unitsInput.value = toUnitsInput(clampedUnits);
+        }
+
+        if (options.origin !== 'amount') {
+            amountInput.value = toAmountInput(amount);
+        }
+
+        proceedsEl.textContent = formatCurrency(amount);
+        updateSliderFromUnits(clampedUnits);
+    }
+
+    function handleAmountChange() {
+        const holding = getHolding();
+        if (!holding) {
+            return;
+        }
+        let amount = Number.parseFloat(amountInput.value);
+        if (!Number.isFinite(amount)) {
+            amount = 0;
+        }
+        amount = Math.max(0, amount);
+        if (amount > holding.value) {
+            amount = holding.value;
+            amountInput.value = toAmountInput(amount);
+        }
+        const units = holding.pricePerUnit ? amount / holding.pricePerUnit : 0;
+        updateFromUnits(units, { origin: 'amount' });
+    }
+
+    function handleUnitsChange() {
+        const holding = getHolding();
+        if (!holding) {
+            return;
+        }
+        let units = Number.parseFloat(unitsInput.value);
+        if (!Number.isFinite(units)) {
+            units = 0;
+        }
+        units = clampUnits(units, holding);
+        if (units !== Number.parseFloat(unitsInput.value)) {
+            unitsInput.value = toUnitsInput(units);
+        }
+        updateFromUnits(units, { origin: 'units' });
+    }
+
+    function handleSliderInput() {
+        const holding = getHolding();
+        if (!holding) {
+            return;
+        }
+        const percent = Number.parseFloat(slider.value) || 0;
+        const units = (percent / 100) * holding.units;
+        updateFromUnits(units, { origin: 'slider' });
+    }
+
+    function openModal() {
+        previouslyFocusedElement = document.activeElement;
+        modal.hidden = false;
+        document.body.classList.add('sell-modal-open');
+        autoInvestCap.disabled = !autoInvestCheckbox.checked;
+        updateAvailableMeta(getHolding());
+        updateFromUnits(0, { origin: 'reset' });
+        slider.value = 0;
+        sliderValue.textContent = '0% of holdings';
+        requestAnimationFrame(() => {
+            propertySelect.focus();
+        });
+    }
+
+    function closeModal() {
+        modal.hidden = true;
+        document.body.classList.remove('sell-modal-open');
+        if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
+            previouslyFocusedElement.focus();
+        }
+    }
+
+    function handleKeyDown(event) {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeModal();
+            return;
+        }
+
+        if (event.key !== 'Tab') {
+            return;
+        }
+
+        const focusable = Array.from(dialog.querySelectorAll(
+            'a[href], button:not([disabled]), textarea, input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )).filter((el) => !el.hasAttribute('aria-hidden'));
+
+        if (!focusable.length) {
+            return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        } else if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        }
+    }
+
+    function resetForm() {
+        amountInput.value = '';
+        unitsInput.value = '';
+        slider.value = 0;
+        sliderValue.textContent = '0% of holdings';
+        updateFromUnits(0, { origin: 'reset' });
+    }
+
+    openButton.addEventListener('click', openModal);
+
+    closeTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', closeModal);
+    });
+
+    modal.addEventListener('keydown', handleKeyDown);
+
+    propertySelect.addEventListener('change', () => {
+        updateAvailableMeta(getHolding());
+        resetForm();
+    });
+
+    modeInputs.forEach((input) => {
+        input.addEventListener('change', () => {
+            if (input.checked) {
+                currentMode = input.value;
+                updateMode();
+            }
+        });
+    });
+
+    amountInput.addEventListener('input', handleAmountChange);
+    unitsInput.addEventListener('input', handleUnitsChange);
+    slider.addEventListener('input', handleSliderInput);
+
+    autoInvestCheckbox.addEventListener('change', () => {
+        autoInvestCap.disabled = !autoInvestCheckbox.checked;
+    });
+
+    form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        closeModal();
+    });
+
+    updateAvailableMeta(getHolding());
+    updateFromUnits(0, { origin: 'initial' });
+    syncToggleStyles();
+})();

--- a/property-details.html
+++ b/property-details.html
@@ -249,8 +249,86 @@
                     </div>
                 </section>
             </div>
+            <div class="buy-cta">
+                <button type="button" class="buy-button" id="openBuyModal">Buy Tokens</button>
+            </div>
         </div>
     </main>
+
+    <div class="buy-modal" id="buyModal" hidden>
+        <div class="buy-modal__overlay" data-buy-close></div>
+        <div class="buy-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="buyModalTitle" tabindex="-1">
+            <button type="button" class="buy-modal__close" data-buy-close aria-label="Close buy details">
+                <i class="fas fa-times"></i>
+            </button>
+            <h2 id="buyModalTitle">Purchase Tokens</h2>
+            <p class="buy-modal__intro">Choose how you would like to commit to this property and preview the expected allocation
+                before checking out.</p>
+            <form class="buy-form" id="buyForm" novalidate>
+                <fieldset class="buy-form__toggle" aria-label="Choose purchase input mode">
+                    <legend class="sr-only">Amount or units selection</legend>
+                    <label class="toggle-option">
+                        <input type="radio" name="buyMode" value="amount" checked>
+                        <span>Amount (RM)</span>
+                    </label>
+                    <label class="toggle-option">
+                        <input type="radio" name="buyMode" value="units">
+                        <span>Units</span>
+                    </label>
+                </fieldset>
+
+                <div class="buy-form__fields">
+                    <div class="form-field" data-mode="amount">
+                        <label for="buyAmount">Amount (RM)</label>
+                        <input type="number" id="buyAmount" name="buyAmount" inputmode="decimal" min="0" step="1"
+                            autocomplete="off">
+                    </div>
+                    <div class="form-field" data-mode="units">
+                        <label for="buyUnits">Units</label>
+                        <input type="number" id="buyUnits" name="buyUnits" inputmode="decimal" min="1" step="1"
+                            autocomplete="off" disabled>
+                    </div>
+                </div>
+
+                <div class="buy-slider">
+                    <div class="buy-slider__header">
+                        <label for="buySlider">Adjust commitment</label>
+                        <span class="buy-slider__range" aria-live="polite">
+                            <span data-slider-min></span>
+                            <span aria-hidden="true">→</span>
+                            <span data-slider-max></span>
+                        </span>
+                    </div>
+                    <input type="range" id="buySlider" name="buySlider" min="0" max="100" value="0">
+                </div>
+
+                <div class="buy-summary">
+                    <div class="summary-item">
+                        <span class="label">Selected amount</span>
+                        <strong data-summary-amount>RM 0</strong>
+                    </div>
+                    <div class="summary-item">
+                        <span class="label">Tokens acquired</span>
+                        <strong data-summary-units>0 tokens</strong>
+                    </div>
+                </div>
+
+                <div class="auto-invest">
+                    <label class="auto-invest__checkbox">
+                        <input type="checkbox" id="autoInvest" name="autoInvest">
+                        <span>Auto-invest?</span>
+                    </label>
+                    <div class="auto-invest__cap">
+                        <label for="autoInvestCap">Cap (% of portfolio)</label>
+                        <input type="number" id="autoInvestCap" name="autoInvestCap" min="1" max="100" step="1" value="15"
+                            disabled>
+                    </div>
+                </div>
+
+                <button type="submit" class="buy-form__submit">Proceed to checkout</button>
+            </form>
+        </div>
+    </div>
 
     <footer>
         <div class="container">


### PR DESCRIPTION
## Summary
- add a sell call-to-action section to the investments page with portfolio totals and modal trigger
- build the sell modal markup with toggles, slider, and auto-invest controls tied to portfolio holdings data
- style the new section and modal while adding JavaScript to keep amount, units, and proceeds summaries in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea24457244832da6fee3192063c267