### PR TITLE
Add spline hero background and deepen dark theme

### DIFF
--- a/css/components/cards.css
+++ b/css/components/cards.css
@@ -1,6 +1,6 @@
 /* Card Base Styles */
 .card {
-    background: var(--dark-gray);
+    background: var(--secondary-black);
     border-radius: 15px;
     border: 1px solid rgba(29, 185, 84, 0.1);
     padding: 30px;
@@ -26,7 +26,7 @@
 
 /* Card Content */
 .card-content {
-    color: var(--text-secondary);
+    color: var(--text-strong);
     font-size: 1.05em;
     line-height: 1.6;
 }

--- a/css/components/hero.css
+++ b/css/components/hero.css
@@ -44,16 +44,18 @@
     margin-left: calc((100vw - 100%) / -2);
     overflow: hidden;
     z-index: 1;
+    min-height: clamp(420px, 70vh, 880px);
 }
 
-.hero-background spline-viewer,
-.hero-background iframe {
+.hero-background__canvas {
+    display: block;
     width: 100%;
     height: 100%;
-    min-height: 720px;
+    min-height: clamp(420px, 70vh, 880px);
     filter: brightness(0.9) saturate(1.1);
     opacity: 0.9;
     pointer-events: none;
+    background: var(--primary-black);
 }
 
 .hero-background__fallback {
@@ -69,7 +71,7 @@
     font-size: 1rem;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    z-index: 0;
+    z-index: 2;
     pointer-events: none;
     transition: opacity 0.6s ease, visibility 0.6s ease;
 }

--- a/css/components/hero.css
+++ b/css/components/hero.css
@@ -1,6 +1,6 @@
 /* Hero Section */
 .hero {
-    background: var(--dark-gray);
+    background: var(--primary-black);
     color: var(--text);
     padding: 40px 0 60px;
     text-align: center;
@@ -14,6 +14,69 @@
     justify-content: center;
     overflow: hidden;
     position: relative;
+}
+
+.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(124, 108, 255, 0.12), transparent 55%),
+                radial-gradient(circle at 80% 10%, rgba(29, 185, 84, 0.08), transparent 50%),
+                linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.75) 90%);
+    pointer-events: none;
+    z-index: 2;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.45) 0%, rgba(0, 0, 0, 0.85) 70%);
+    pointer-events: none;
+    z-index: 3;
+}
+
+.hero-background {
+    position: absolute;
+    inset: -10% 0 0;
+    width: 100vw;
+    max-width: none;
+    margin-left: calc((100vw - 100%) / -2);
+    overflow: hidden;
+    z-index: 1;
+}
+
+.hero-background spline-viewer,
+.hero-background iframe {
+    width: 100%;
+    height: 100%;
+    min-height: 720px;
+    filter: brightness(0.9) saturate(1.1);
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.hero-background__fallback {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: radial-gradient(circle at 30% 30%, rgba(124, 108, 255, 0.18), transparent 60%),
+                radial-gradient(circle at 70% 70%, rgba(29, 185, 84, 0.15), transparent 65%),
+                linear-gradient(180deg, rgba(11, 11, 15, 0.85) 0%, rgba(0, 0, 0, 0.9) 100%);
+    color: var(--text-strong);
+    font-size: 1rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    z-index: 0;
+    pointer-events: none;
+    transition: opacity 0.6s ease, visibility 0.6s ease;
+}
+
+.hero-background__fallback.is-hidden {
+    opacity: 0;
+    visibility: hidden;
 }
 
 .hero .container {
@@ -79,7 +142,7 @@ body.animations-enabled .hero h1 {
 }
 
 .hero p {
-    color: rgba(255, 255, 255, 0.7);
+    color: var(--text);
     font-size: 1.2em;
     max-width: 800px;
     margin: 0 auto 5px;
@@ -87,7 +150,7 @@ body.animations-enabled .hero h1 {
     line-height: 1.7;
     position: relative;
     z-index: 10;
-    white-space: nowrap;
+    white-space: normal;
     overflow: visible;
 }
 

--- a/css/components/navigation.css
+++ b/css/components/navigation.css
@@ -154,8 +154,8 @@
 }
 
 .contact-btn {
-    background: var(--secondary);
-    color: var(--primary);
+    background: var(--contact-accent);
+    color: var(--text);
     padding: 10px 20px;
     border-radius: 8px;
     text-decoration: none;
@@ -164,7 +164,7 @@
 }
 
 .contact-btn:hover {
-    background: #1ed760;
+    background: #938bff;
     transform: translateY(-2px);
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -4,12 +4,17 @@
 /* Variables */
 :root {
     --primary: #000000;
+    --primary-black: #000000;
+    --secondary-black: #0b0b0f;
+    --tertiary-black: #141414;
     --secondary: #1DB954;  /* Spotify-like green for accents */
+    --contact-accent: #7C6CFF;
     --text: #FFFFFF;
+    --text-strong: rgba(255, 255, 255, 0.92);
     --text-secondary: rgba(255, 255, 255, 0.7);
-    --dark-gray: #121212;
-    --medium-gray: #1E1E1E;
-    --light-gray: #404040;
+    --dark-gray: #050505;
+    --medium-gray: #0b0b0f;
+    --light-gray: #1E1E1E;
 }
 
 /* Base Styles */
@@ -22,7 +27,7 @@
 body {
     line-height: 1.6;
     color: var(--text, #FFFFFF);
-    background: var(--dark-gray, #121212);
+    background: var(--primary-black, #000000);
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     animation: fadeIn 0.3s ease-in;
 }
@@ -64,7 +69,7 @@ h3 {
 p {
     font-size: 1.1em;
     line-height: 1.8;
-    color: var(--text-secondary);
+    color: var(--text-strong);
     margin-bottom: 15px;
     max-width: 800px;
 }
@@ -121,7 +126,7 @@ html {
 
 /* Add fallbacks for critical styles */
 body {
-    background-color: var(--dark-gray, #121212);
+    background-color: var(--primary-black, #000000);
     color: var(--text, #FFFFFF);
 }
 

--- a/index.html
+++ b/index.html
@@ -26,8 +26,7 @@
     <link rel="stylesheet" href="css/components/animations.css">
     <script src="js/code-showcase.js" defer></script>
     <script src="js/animations.js" defer></script>
-    <script type="module" src="https://unpkg.com/@splinetool/viewer@0.9.518/build/spline-viewer.js"></script>
-    <script src="js/spline-background.js" defer></script>
+    <script type="module" src="js/spline-background.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet">
     <!-- Make sure this is in the head section -->
     <link rel="stylesheet" href="css/components/chat.css">
@@ -68,9 +67,9 @@
     </nav>
 
     <header class="hero">
-        <div class="hero-background">
-            <spline-viewer url="loading..." loading="eager" aria-label="Interactive blockchain skyline"></spline-viewer>
-            <div class="hero-background__fallback">Interactive background loading</div>
+        <div class="hero-background" aria-hidden="true">
+            <canvas id="canvas3d" class="hero-background__canvas"></canvas>
+            <div class="hero-background__fallback" role="status">Interactive background loading</div>
         </div>
         <div class="floating-orb orb-1"></div>
         <div class="floating-orb orb-2"></div>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
     <link rel="stylesheet" href="css/components/animations.css">
     <script src="js/code-showcase.js" defer></script>
     <script src="js/animations.js" defer></script>
+    <script type="module" src="https://unpkg.com/@splinetool/viewer@0.9.518/build/spline-viewer.js"></script>
+    <script src="js/spline-background.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet">
     <!-- Make sure this is in the head section -->
     <link rel="stylesheet" href="css/components/chat.css">
@@ -66,6 +68,10 @@
     </nav>
 
     <header class="hero">
+        <div class="hero-background">
+            <spline-viewer url="loading..." loading="eager" aria-label="Interactive blockchain skyline"></spline-viewer>
+            <div class="hero-background__fallback">Interactive background loading</div>
+        </div>
         <div class="floating-orb orb-1"></div>
         <div class="floating-orb orb-2"></div>
         <div class="floating-orb orb-3"></div>

--- a/js/spline-background.js
+++ b/js/spline-background.js
@@ -1,0 +1,46 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var heroBackground = document.querySelector('.hero-background');
+        if (!heroBackground) {
+            return;
+        }
+
+        var viewer = heroBackground.querySelector('spline-viewer');
+        var fallback = heroBackground.querySelector('.hero-background__fallback');
+
+        if (!viewer) {
+            if (fallback) {
+                fallback.textContent = 'Interactive background unavailable';
+            }
+            return;
+        }
+
+        var hideFallback = function () {
+            if (fallback) {
+                fallback.classList.add('is-hidden');
+            }
+        };
+
+        var showError = function () {
+            if (fallback) {
+                fallback.textContent = 'Interactive background unavailable';
+                fallback.classList.remove('is-hidden');
+            }
+        };
+
+        viewer.addEventListener('load', hideFallback);
+        viewer.addEventListener('scene-load', hideFallback);
+        viewer.addEventListener('error', showError);
+
+        if (viewer.hasAttribute('data-spline-loaded')) {
+            hideFallback();
+        }
+
+        // Ensure the fallback transitions away after a delay to reduce overlap during slow loads.
+        setTimeout(function () {
+            if (viewer.hasAttribute('url') && viewer.getAttribute('url') !== '') {
+                hideFallback();
+            }
+        }, 6000);
+    });
+})();

--- a/js/spline-background.js
+++ b/js/spline-background.js
@@ -1,46 +1,58 @@
-(function () {
-    document.addEventListener('DOMContentLoaded', function () {
-        var heroBackground = document.querySelector('.hero-background');
-        if (!heroBackground) {
-            return;
+import { Application } from 'https://unpkg.com/@splinetool/runtime?module';
+
+const SCENE_URL = 'https://prod.spline.design/gxgXLmiwIASvMdmE/scene.splinecode';
+
+const hideFallback = (fallback) => {
+    if (!fallback) {
+        return;
+    }
+
+    fallback.classList.add('is-hidden');
+};
+
+const showFallback = (fallback, message) => {
+    if (!fallback) {
+        return;
+    }
+
+    if (message) {
+        fallback.textContent = message;
+    }
+
+    fallback.classList.remove('is-hidden');
+};
+
+const initializeSplineBackground = () => {
+    const canvas = document.getElementById('canvas3d');
+    if (!canvas) {
+        return;
+    }
+
+    const fallback = canvas.parentElement?.querySelector('.hero-background__fallback');
+
+    if (fallback) {
+        fallback.textContent = 'Interactive background loading';
+    }
+
+    try {
+        const app = new Application(canvas);
+        const loadPromise = app.load(SCENE_URL);
+
+        if (loadPromise && typeof loadPromise.then === 'function') {
+            loadPromise
+                .then(() => {
+                    hideFallback(fallback);
+                })
+                .catch(() => {
+                    showFallback(fallback, 'Interactive background unavailable');
+                });
+        } else {
+            hideFallback(fallback);
         }
+    } catch (error) {
+        console.error('Failed to initialize Spline background', error);
+        showFallback(fallback, 'Interactive background unavailable');
+    }
+};
 
-        var viewer = heroBackground.querySelector('spline-viewer');
-        var fallback = heroBackground.querySelector('.hero-background__fallback');
-
-        if (!viewer) {
-            if (fallback) {
-                fallback.textContent = 'Interactive background unavailable';
-            }
-            return;
-        }
-
-        var hideFallback = function () {
-            if (fallback) {
-                fallback.classList.add('is-hidden');
-            }
-        };
-
-        var showError = function () {
-            if (fallback) {
-                fallback.textContent = 'Interactive background unavailable';
-                fallback.classList.remove('is-hidden');
-            }
-        };
-
-        viewer.addEventListener('load', hideFallback);
-        viewer.addEventListener('scene-load', hideFallback);
-        viewer.addEventListener('error', showError);
-
-        if (viewer.hasAttribute('data-spline-loaded')) {
-            hideFallback();
-        }
-
-        // Ensure the fallback transitions away after a delay to reduce overlap during slow loads.
-        setTimeout(function () {
-            if (viewer.hasAttribute('url') && viewer.getAttribute('url') !== '') {
-                hideFallback();
-            }
-        }, 6000);
-    });
-})();
+document.addEventListener('DOMContentLoaded', initializeSplineBackground);


### PR DESCRIPTION
## Summary
- embed the Spline viewer and a graceful fallback behind the hero section
- refresh the global dark palette to emphasize ultra-black surfaces and brighter typography
- update cards and the contact call-to-action to align with the new contrast guidelines

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ea5f55d19c832d9c3e8e1075d31170